### PR TITLE
Fix README code example

### DIFF
--- a/lab4/README.md
+++ b/lab4/README.md
@@ -38,7 +38,7 @@ def figMetaData(file_path):
 
 
 def pdfMetaData(file_path):
-    pdf_doc = PdfReader(open(path, "rb"))
+    pdf_doc = PdfReader(open(file_path, "rb"))
     if pdf_doc.is_encrypted:
         pdf_doc.decrypt("PASSWORD_GOES_HERE")
 


### PR DESCRIPTION
## Summary
- fix usage of variable `path` in lab4 README code snippet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7c5a8c688331b46a78689525ffcc