### PR TITLE
Add verify_image_hash module and tests

### DIFF
--- a/lab1/verify_image_hash.py
+++ b/lab1/verify_image_hash.py
@@ -1,0 +1,20 @@
+import hashlib
+
+
+def verify_image_hash(image_path: str, given_hash: str) -> bool:
+    """Verify SHA-1 hash of the image against the expected value."""
+    try:
+        with open(image_path, 'rb') as f:
+            computed_hash = hashlib.sha1(f.read()).hexdigest()
+        if computed_hash == given_hash:
+            print('Bitstream image verified successfully.')
+            return True
+        else:
+            print('Error: Bitstream image verification failed.')
+            return False
+    except IOError as e:
+        print(f"Error opening file: {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False

--- a/tests/test_verify_image_hash.py
+++ b/tests/test_verify_image_hash.py
@@ -1,0 +1,18 @@
+import hashlib
+from pathlib import Path
+from lab1.verify_image_hash import verify_image_hash
+
+
+def test_verify_image_hash_matches(tmp_path: Path):
+    file_path = tmp_path / "sample.txt"
+    content = b"sample data"
+    file_path.write_bytes(content)
+    expected_hash = hashlib.sha1(content).hexdigest()
+    assert verify_image_hash(str(file_path), expected_hash) is True
+
+
+def test_verify_image_hash_mismatch(tmp_path: Path):
+    file_path = tmp_path / "sample.txt"
+    file_path.write_bytes(b"other data")
+    wrong_hash = hashlib.sha1(b"different").hexdigest()
+    assert verify_image_hash(str(file_path), wrong_hash) is False


### PR DESCRIPTION
## Summary
- implement `verify_image_hash` in `lab1`
- add a minimal package init for `lab1`
- create tests that cover both matching and mismatched hashes

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7d68fcc0833181904681148b7a4b