### PR TITLE
Fix typo in lab3 README

### DIFF
--- a/lab3/README.md
+++ b/lab3/README.md
@@ -37,7 +37,7 @@ with open(log_path, "r") as log_file:
      # Find all USB device installation events and extract information about each device
 ```
 
-Upotrijebite sljedeći regularni izraz da nađete sve USB uređaje - možete koristiti `re.match` finkciju:
+Upotrijebite sljedeći regularni izraz da nađete sve USB uređaje - možete koristiti `re.match` funkciju:
 
 ```python
 r'^>>>  \[Device Install.*#(Disk&Ven_[A-Za-z0-9]+)&(Prod_([\w\s\S]+?))&(Rev_([\w\s\S]+?))#([\w\s\S]+?)#.*\]'


### PR DESCRIPTION
## Summary
- fix a typo in the lab3 README around the `re.match` usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7d4fe654833190c2e84ed3aafcd1